### PR TITLE
Resolve #12 - Incorrect handling of request body

### DIFF
--- a/java/Utils.java
+++ b/java/Utils.java
@@ -21,9 +21,8 @@ public class Utils {
         return b;
     }
 
-    public static long toByteBuffer(InputStream is)
+    public static long toByteBuffer(byte[] bytes)
       throws IOException {
-        byte[] bytes=toByteArray(is);
         long address = MemoryManager.allocateBuffer(bytes.length,true);
         ByteBuffer buf = MemoryManager.getBoundedBuffer(address);
         buf.put(bytes);
@@ -51,15 +50,6 @@ public class Utils {
         }
     }
 
-    public static int size(long address) {
-        ByteBuffer buf = MemoryManager.getBoundedBuffer(address);
-        return size(buf);
-    }
-    
-    public static int size(ByteBuffer buf) {
-        return buf.remaining();
-    }
-
     public static void sendFile(OutputStream os, String pathStr,
         long offSet, long len, long size) throws IOException {
 
@@ -75,7 +65,6 @@ public class Utils {
 
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
         int read;
-        
         if (inputSize == length) {
             // Write full range.
             while ((read = input.read(buffer)) > 0) {
@@ -85,7 +74,6 @@ public class Utils {
         } else {
             input.skip(start);
             long toRead = length;
-            
             while ((read = input.read(buffer)) > 0) {
                 if ((toRead -= read) > 0) {
                     output.write(buffer, 0, read);

--- a/wai-servlet.cabal
+++ b/wai-servlet.cabal
@@ -1,5 +1,5 @@
 name:                wai-servlet
-version:             0.1.3.0
+version:             0.1.4.0
 -- synopsis:            
 -- description:         
 license:             BSD3
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 source-repository this
   type:              git
   location:          https://github.com/jneira/wai-servlet 
-  tag:               0.1.3.0
+  tag:               0.1.4.0
 
 Flag wai-servlet-debug
     Description: print debug output. not suitable for production


### PR DESCRIPTION
This change in the internals handles both the behavior of the old MemoryManager as well as the new one by keeping tracking of an intermediate `byte[]` on the Eta side.

I also attempted to plug a memory leak in the data allocated for the request body via a `ForeignPtr` finalizer but it triggered a subtle bug in the new MemoryManager. I left a comment noting this. I will file an issue.