### PR TITLE
Add settings to parametrize wai-servlet execution

### DIFF
--- a/src/Javax/Servlet.hs
+++ b/src/Javax/Servlet.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE MagicHash,TypeFamilies,DataKinds,FlexibleContexts,
+             OverloadedStrings, TypeOperators,CPP #-}
+module Javax.Servlet where
+
+import Java
+import Java.Array
+#ifdef INTEROP
+import qualified Interop.Java.IO as JIO
+#else
+import qualified Java.IO as JIO
+#endif
+
+-- Servlet
+
+data {-# CLASS "javax.servlet.GenericServlet" #-} GenericServlet =
+  GenericServlet (Object# GenericServlet) deriving Class
+
+-- Request
+
+data {-# CLASS "javax.servlet.ServletRequest" #-}
+  ServletRequest = ServletRequest (Object# ServletRequest)
+  deriving Class
+
+data {-# CLASS "javax.servlet.http.HttpServletRequest" #-}
+  HttpServletRequest = HttpServletRequest (Object# HttpServletRequest)
+  deriving Class
+
+data {-# CLASS "javax.servlet.ServletInputStream" #-}
+  ServletInputStream = ServletInputStream (Object# ServletInputStream)
+  deriving Class
+
+type instance Inherits HttpServletRequest = '[ServletRequest]
+type instance Inherits ServletInputStream = '[JIO.InputStream]
+
+foreign import java unsafe "@interface getCharacterEncoding" getCharacterEncoding ::
+  (a <: ServletRequest) => Java a String
+foreign import java unsafe "@interface getProtocol" getProtocol ::
+  (a <: ServletRequest) => Java a String
+foreign import java unsafe "@interface isSecure" isSecure ::
+  (a <: ServletRequest) => Java a Bool
+foreign import java unsafe "@interface getRemoteAddr" getRemoteAddr ::
+  (a <: ServletRequest) => Java a String
+foreign import java unsafe "@interface getRemotePort" getRemotePort ::
+  (a <: ServletRequest) => Java a Int
+foreign import java unsafe "@interface getInputStream" getInputStream ::
+  (a <: ServletRequest) => Java a ServletInputStream
+foreign import java unsafe "@interface getContentLength" getContentLength ::
+  (a <: ServletRequest) => Java a Int
+
+foreign import java unsafe "@interface getMethod" getMethod ::
+  (a <: HttpServletRequest) => Java a String
+foreign import java unsafe "@interface getPathInfo" getPathInfo ::
+  (a <: HttpServletRequest) => Java a (Maybe String)
+foreign import java unsafe "@interface getQueryString" getQueryString ::
+  (a <: HttpServletRequest) => Java a (Maybe String)
+foreign import java unsafe "@interface getHeaderNames" getHeaderNames ::
+  (a <: HttpServletRequest) => Java a (Enumeration JString)
+foreign import java unsafe "@interface getHeaders" getHeaders ::
+  (a <: HttpServletRequest) => String -> Java a (Maybe (Enumeration JString))
+
+-- Response
+
+data {-# CLASS "javax.servlet.ServletResponse" #-}
+  ServletResponse = ServletResponse (Object# ServletResponse)
+  deriving Class
+
+data {-# CLASS "javax.servlet.http.HttpServletResponse" #-}
+  HttpServletResponse = HttpServletResponse (Object# HttpServletResponse)
+  deriving Class
+
+type instance Inherits HttpServletResponse = '[ServletResponse]
+
+data {-# CLASS "javax.servlet.ServletOutputStream" #-}
+  ServletOutputStream = ServletOutputStream (Object# ServletOutputStream)
+  deriving Class
+
+type instance Inherits ServletOutputStream = '[JIO.OutputStream]
+
+foreign import java unsafe "@interface setStatus" setStatus ::
+   Int -> Java HttpServletResponse ()
+foreign import java unsafe "@interface setHeader" setHeader ::
+   String -> String -> Java HttpServletResponse ()
+foreign import java unsafe "@interface getOutputStream" getOutputStream ::
+   (a <: ServletResponse) => Java a ServletOutputStream
+foreign import java unsafe "@interface flushBuffer" flushBuffer ::
+   (a <: ServletResponse) => Java a ()
+foreign import java unsafe "@interface getBufferSize" getBufferSize ::
+   (a <: ServletResponse) => Java a Int

--- a/src/Network/Wai/Servlet.hs
+++ b/src/Network/Wai/Servlet.hs
@@ -9,18 +9,26 @@ module Network.Wai.Servlet
     , makeServlet
     , module Network.Wai.Servlet.Request
     , module Network.Wai.Servlet.Response
-    ) where
+    , module Network.Wai.Servlet.Settings ) where
 import Network.Wai.Servlet.Response
 import Network.Wai.Servlet.Request
+import Network.Wai.Servlet.Settings
 import qualified Network.Wai as Wai
 import qualified Network.HTTP.Types as HTTP
 import Java
-
-data {-# CLASS "javax.servlet.GenericServlet" #-} GenericServlet =
-  GenericServlet (Object# GenericServlet) deriving Class
+import Javax.Servlet
 
 type ServletApplication a = ServletRequest -> ServletResponse -> Java a ()
 type GenericServletApplication = ServletApplication GenericServlet
+
+-- Types for create a Servlet that can be used
+-- to create war packages to deploy in j2ee servers
+-- using "foreign export java service :: DefaultWaiServletApplication"
+data {-# CLASS "network.wai.servlet.DefaultWaiServlet extends javax.servlet.GenericServlet" #-}
+  DefaultWaiServlet = DefaultWaiServlet (Object# DefaultWaiServlet)
+                    deriving Class
+type instance Inherits DefaultWaiServlet = '[GenericServlet]
+type DefaultWaiServletApplication = ServletApplication DefaultWaiServlet
 
 makeServiceMethod :: (a <: GenericServlet) =>
   Wai.Application -> ServletApplication a
@@ -31,17 +39,6 @@ makeServiceMethod waiApp servReq servResp =
         httpServResp = unsafeCast servResp
         waiReq = makeWaiRequest httpServReq
         waiRespond = updateHttpServletResponse httpServReq httpServResp  
-
--- Types for create a Servlet that can be used for create war packages to deploy in j2ee servers
--- using "foreign export java service :: DefaultWaiServletApplication"
-data {-# CLASS "network.wai.servlet.DefaultWaiServlet extends javax.servlet.GenericServlet" #-}
-  DefaultWaiServlet = DefaultWaiServlet (Object# DefaultWaiServlet)
-                    deriving Class
-
-type instance Inherits DefaultWaiServlet = '[GenericServlet]
-
-type DefaultWaiServletApplication = ServletApplication DefaultWaiServlet
-
 
 -- Make a proxy servlet to use programatically in embedded j2ee servers (tomcar,jetty)
 foreign import java unsafe "@wrapper @abstract service"

--- a/src/Network/Wai/Servlet.hs
+++ b/src/Network/Wai/Servlet.hs
@@ -32,13 +32,18 @@ type DefaultWaiServletApplication = ServletApplication DefaultWaiServlet
 
 makeServiceMethod :: (a <: GenericServlet) =>
   Wai.Application -> ServletApplication a
-makeServiceMethod waiApp servReq servResp =
+makeServiceMethod = makeServiceMethodSettings defaultSettings
+
+makeServiceMethodSettings :: (a <: GenericServlet) =>
+  Settings -> Wai.Application -> ServletApplication a
+makeServiceMethodSettings settings waiApp servReq servResp =
   do io $ waiApp waiReq waiRespond
      return ()
   where httpServReq = unsafeCast servReq
         httpServResp = unsafeCast servResp
-        waiReq = makeWaiRequest httpServReq
-        waiRespond = updateHttpServletResponse httpServReq httpServResp  
+        waiReq = makeWaiRequestSettings settings httpServReq
+        waiRespond = updateHttpServletResponseSettings settings
+                     httpServReq httpServResp  
 
 -- Make a proxy servlet to use programatically in embedded j2ee servers (tomcar,jetty)
 foreign import java unsafe "@wrapper @abstract service"

--- a/src/Network/Wai/Servlet/Examples.hs
+++ b/src/Network/Wai/Servlet/Examples.hs
@@ -72,12 +72,13 @@ servShowReq :: DefaultWaiServletApplication
 servShowReq = makeServiceMethod appShowReq 
 
 appAll :: FilePath -> Application
-appAll filePath req respond = case pathInfo req of
+appAll filePath req respond = case path of
   ["state"]        -> appState (unsafePerformIO $ newMVar 0) req respond
   ["stream"]       -> appStream req respond
-  ["request-info"] -> appShowReq req respond
   ["static-file"]  -> appFile filePath req respond
+  "request-info":_ -> appShowReq req respond
   _                -> appSimple req respond
+  where path = pathInfo req
 
 servAll :: DefaultWaiServletApplication
 servAll = makeServiceMethod $ appAll "index.html"

--- a/src/Network/Wai/Servlet/Request.hs
+++ b/src/Network/Wai/Servlet/Request.hs
@@ -78,8 +78,22 @@ foreign import java unsafe "@static network.wai.servlet.Utils.toByteBuffer"
 foreign import java unsafe "@static network.wai.servlet.Utils.size"
    size :: Ptr Word8 -> Int
 
+data CharEncoding = ISO88591 | UTF8
+
+data WaiRequestSettings = WaiRequestSettings
+  { uriEncoding :: CharEncoding }
+
+defaultWaiRequestSettings :: WaiRequestSettings
+defaultWaiRequestSettings = WaiRequestSettings
+  { uriEncoding = UTF8 }
+
 makeWaiRequest :: HttpServletRequest -> W.Request
-makeWaiRequest req  =  W.Request
+makeWaiRequest = makeWaiRequestWithSettings
+                 defaultWaiRequestSettings  
+
+makeWaiRequestWithSettings :: WaiRequestSettings -> HttpServletRequest
+                           -> W.Request
+makeWaiRequestWithSettings settings req = W.Request
    { W.requestMethod = requestMethod req 
    , W.httpVersion = httpVersion req
    , W.rawPathInfo = rawPath
@@ -96,10 +110,11 @@ makeWaiRequest req  =  W.Request
    , W.requestHeaderRange = header "Range"
    , W.requestHeaderReferer = header "Referer"
    , W.requestHeaderUserAgent = header "User-Agent"
-  }
-  where rawPath = rawPathInfo req
-        path = H.decodePathSegments $ pathInfo req
-        rawQuery = queryString req
+   }
+  where encoding = uriEncoding settings
+        rawPath = rawPathInfo encoding req
+        path = H.decodePathSegments $ pathInfo encoding req
+        rawQuery = queryString encoding req
         query = H.parseQuery rawQuery
         header name = fmap snd $ requestHeader req name
 
@@ -116,29 +131,30 @@ httpVersion req = pureJavaWith req $ do
     "HTTP/1.0" -> H.http10
     "HTTP/1.1" -> H.http11
 
-encode ::  Maybe String -> B.ByteString
-encode Nothing = B.empty
-encode (Just str) =  BSUTF8.fromString str
+encode ::  CharEncoding -> Maybe String -> B.ByteString
+encode _ Nothing = B.empty
+encode UTF8 (Just str) =  BSUTF8.fromString str
+encode ISO88591 (Just str) = BSChar.pack str
 
-rawPathInfo :: (a <: HttpServletRequest) => a -> B.ByteString
-rawPathInfo req = pureJavaWith req $ do
+rawPathInfo :: (a <: HttpServletRequest) => CharEncoding -> a -> B.ByteString
+rawPathInfo enc req = pureJavaWith req $ do
   path <- getPathInfo
   case path of
     Nothing -> return B.empty
     Just str -> do
       let segments = wordsWhen (=='/') str
       return $ B.intercalate "/" $
-        map (H.urlEncode False . encode . Just) segments
+        map (H.urlEncode False . encode enc . Just) segments
 
-pathInfo :: (a <: HttpServletRequest) => a -> B.ByteString
-pathInfo req = pureJavaWith req $ do
+pathInfo :: (a <: HttpServletRequest) => CharEncoding -> a -> B.ByteString
+pathInfo enc req = pureJavaWith req $ do
   path <- getPathInfo
-  return $ encode path
+  return $ encode enc path
 
-queryString :: (a <: HttpServletRequest) => a -> B.ByteString
-queryString req = pureJavaWith req $ do
+queryString :: (a <: HttpServletRequest) => CharEncoding -> a -> B.ByteString
+queryString enc req = pureJavaWith req $ do
   query <- getQueryString
-  return $ encode query
+  return $ encode enc query
 
 requestHeaders :: (a <: HttpServletRequest) => a -> H.RequestHeaders
 requestHeaders req = pureJavaWith req $ do

--- a/src/Network/Wai/Servlet/Request.hs
+++ b/src/Network/Wai/Servlet/Request.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE MagicHash,TypeFamilies,DataKinds,FlexibleContexts,
-             OverloadedStrings, TypeOperators,CPP #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, TypeOperators,
+             ScopedTypeVariables, CPP #-}
 module Network.Wai.Servlet.Request
     ( HttpServletRequest
     , ServletRequest

--- a/src/Network/Wai/Servlet/Response.hs
+++ b/src/Network/Wai/Servlet/Response.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE MagicHash,TypeFamilies,DataKinds,FlexibleContexts,
-             MultiParamTypeClasses,TypeOperators,RecordWildCards,
-             OverloadedStrings,CPP,ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts, TypeOperators, RecordWildCards,
+             OverloadedStrings,CPP, ScopedTypeVariables #-}
 
 module Network.Wai.Servlet.Response
     ( HttpServletResponse

--- a/src/Network/Wai/Servlet/Response.hs
+++ b/src/Network/Wai/Servlet/Response.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Internal as BSLInt
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BSInt
-import qualified Data.ByteString.Char8 as BSChar (unpack,pack)
+import qualified Data.ByteString.Char8 as BSChar (unpack)
 import Foreign.ForeignPtr (ForeignPtr,withForeignPtr)
 import Foreign.Ptr (Ptr)
 import Data.Word (Word8)
@@ -85,7 +85,8 @@ sendChunk resp builder = javaWith resp $ do
 flush :: (a <: ServletResponse) => a -> IO ()
 flush resp = javaWith resp flushBuffer
 
-setStatusAndHeaders :: HTTP.Status -> [HTTP.Header] -> Java HttpServletResponse ()  
+setStatusAndHeaders :: HTTP.Status -> [HTTP.Header]
+                    -> Java HttpServletResponse ()  
 setStatusAndHeaders status headers = do
   setStatus $ HTTP.statusCode status
   forM_ headers $ \ (name,value) -> do
@@ -114,8 +115,9 @@ writeStrictByteString bss = do
         getByteArray = withForeignPtr fptr $ \ ptr -> 
                          return $ toByteArray ptr offset length
 
-sendRspFile :: HTTP.Status -> HTTP.ResponseHeaders -> HTTP.RequestHeaders -> FilePath
-            -> Maybe WaiIn.FilePart -> Bool -> Java HttpServletResponse ()
+sendRspFile :: HTTP.Status -> HTTP.ResponseHeaders -> HTTP.RequestHeaders
+            -> FilePath -> Maybe WaiIn.FilePart -> Bool
+            -> Java HttpServletResponse ()
 -- Sophisticated WAI applications.
 -- We respect status. status MUST be a proper value.
 sendRspFile status hdrs _ path (Just part) isHead = do
@@ -151,6 +153,7 @@ sendRspFile404 hdrs = sendRspBuilder HTTP.notFound404 hdrs' body
 
 type HeaderValue = BS.ByteString
 
-replaceHeader :: HTTP.HeaderName -> HeaderValue -> [HTTP.Header] -> [HTTP.Header]
+replaceHeader :: HTTP.HeaderName -> HeaderValue -> [HTTP.Header]
+              -> [HTTP.Header]
 replaceHeader k v hdrs = (k,v) : deleteBy ((==) `on` fst) (k,v) hdrs
 

--- a/src/Network/Wai/Servlet/Response.hs
+++ b/src/Network/Wai/Servlet/Response.hs
@@ -3,7 +3,8 @@
 module Network.Wai.Servlet.Response
     ( HttpServletResponse
     , ServletResponse
-    , updateHttpServletResponse ) where
+    , updateHttpServletResponse
+    , updateHttpServletResponseSettings ) where
 import Control.Monad (forM_,when,unless)
 import Control.Exception as E
 import Data.Function (on)

--- a/src/Network/Wai/Servlet/Settings.hs
+++ b/src/Network/Wai/Servlet/Settings.hs
@@ -1,17 +1,39 @@
+{-# LANGUAGE FlexibleContexts, TypeOperators, CPP, ScopedTypeVariables #-}
+
 module Network.Wai.Servlet.Settings
     ( Settings
     , CharEncoding (..)
     , defaultSettings
     , setUriEncoding
-    , getUriEncoding ) where
+    , getUriEncoding
+    , setFileSender
+    , getFileSender
+    , FilePart) where
+import Network.Wai.Internal
+import Java
+#ifdef INTEROP
+import qualified Interop.Java.IO as JIO
+#else
+import qualified Java.IO as JIO
+#endif
+import Javax.Servlet
+
+foreign import java unsafe "@static network.wai.servlet.Utils.sendFile"
+   sendFile :: (os <: JIO.OutputStream) =>
+                os -> String -> Int64 -> Int64 -> Int64 -> Java a ()
 
 data CharEncoding = ISO88591 | UTF8
 
+type FileSender = FilePath -> FilePart -> Java HttpServletResponse ()
+
 data Settings = Settings
-  { settingUriEncoding :: CharEncoding }
+  { settingUriEncoding :: CharEncoding
+  , settingFileSender  :: FileSender }
 
 defaultSettings :: Settings
-defaultSettings = Settings { settingUriEncoding = UTF8 }
+defaultSettings = Settings
+  { settingUriEncoding = UTF8
+  , settingFileSender  = defaultFileSender }
 
 setUriEncoding :: CharEncoding -> Settings -> Settings
 setUriEncoding x y = y { settingUriEncoding = x }
@@ -19,3 +41,14 @@ setUriEncoding x y = y { settingUriEncoding = x }
 getUriEncoding :: Settings -> CharEncoding
 getUriEncoding = settingUriEncoding 
 
+setFileSender :: FileSender -> Settings -> Settings
+setFileSender x y = y { settingFileSender = x }
+
+getFileSender :: Settings -> FileSender
+getFileSender = settingFileSender
+
+defaultFileSender :: FilePath -> FilePart -> Java HttpServletResponse ()
+defaultFileSender path (FilePart off len size) = do
+  os <- getOutputStream
+  let [off',len',size'] = map fromIntegral [off,len,size]
+  sendFile os path off' len' size'

--- a/src/Network/Wai/Servlet/Settings.hs
+++ b/src/Network/Wai/Servlet/Settings.hs
@@ -1,0 +1,21 @@
+module Network.Wai.Servlet.Settings
+    ( Settings
+    , CharEncoding (..)
+    , defaultSettings
+    , setUriEncoding
+    , getUriEncoding ) where
+
+data CharEncoding = ISO88591 | UTF8
+
+data Settings = Settings
+  { settingUriEncoding :: CharEncoding }
+
+defaultSettings :: Settings
+defaultSettings = Settings { settingUriEncoding = UTF8 }
+
+setUriEncoding :: CharEncoding -> Settings -> Settings
+setUriEncoding x y = y { settingUriEncoding = x }
+
+getUriEncoding :: Settings -> CharEncoding
+getUriEncoding = settingUriEncoding 
+

--- a/wai-servlet.cabal
+++ b/wai-servlet.cabal
@@ -22,11 +22,13 @@ Flag wai-servlet-debug
 
 library
   exposed-modules:     Network.Wai.Servlet
-                     , Network.Wai.Servlet.Examples 
+                     , Network.Wai.Servlet.Examples
   other-modules:       Network.Wai.Servlet.Request
                      , Network.Wai.Servlet.Response
                      , Network.Wai.Servlet.File
-  -- other-extensions:    
+                     , Network.Wai.Servlet.Settings
+                     , Javax.Servlet
+  -- other-extensions:
   build-depends:       base >= 4.8 && < 4.9
                      , wai
                      , network
@@ -40,7 +42,7 @@ library
   if impl(eta >= 0.0.9.7)
      build-depends:    eta-java-interop
      cpp-options:      -DINTEROP
-  hs-source-dirs:      src      
+  hs-source-dirs:      src
   default-language:    Haskell2010
   maven-depends:       javax.servlet:servlet-api:2.5
   if impl(eta >= 0.0.9)


### PR DESCRIPTION
The new settings are used to let client code:
* Choose the uri encoding, between utf-8 and iso-8859, as commented in #5 
* Provide a callback function to send the static file  (to use java.nio f.e. as commented in #8) 